### PR TITLE
🐞 fix & ✨ feat: 修复了无法加载配置的问题，重构日志文件注册逻辑

### DIFF
--- a/nonebot_plugin_logpile/__init__.py
+++ b/nonebot_plugin_logpile/__init__.py
@@ -1,11 +1,19 @@
 from datetime import datetime
+from nonebot import get_plugin_config
+from nonebot.plugin import PluginMetadata
 from typing import Any, Dict, List, Tuple, Union, get_args
 
-from nonebot import get_driver, logger
+from nonebot import logger
 
 from .config import Config, LevelName
 
-pc = Config.parse_obj(get_driver().config)
+__plugin_meta__ = PluginMetadata(
+    name="nonebot-plugin-logpile",
+    description="将 nonebot 的日志记录保存到本地文件",
+    usage="",
+    config=Config,
+)
+pc = get_plugin_config(Config)
 
 LOG_CONFIG = {
     "rotation": "00:00",
@@ -20,8 +28,9 @@ def file_handler(
 ) -> List[Dict[str, Any]]:
     if not isinstance(levels, tuple):
         level_names = get_args(LevelName)
-        minimum = level_names.index(levels)
-        levels = level_names[minimum:]
+        # check if level exists
+        level_index = level_names.index(levels)
+        levels = tuple([level_names[level_index]])
     return [
         {
             "sink": pc.logpile_path


### PR DESCRIPTION
### 这个 PR 带来了什么样的更改？

- [x] 错误修复
- [x] 新功能
- [x] 代码重构


### 描述

1. 修复了无法加载配置的问题
原配置解析方法 `Config.parse_obj(get_driver().config)` 已过时，更改为 `get_plugin_config(Config)` 并补充插件元数据
2. 调整了日志文件注册逻辑

原先逻辑为：
- 当 `logpile_level` 配置非元组时，插件会自动选取所有 <= 配置的日志等级 的等级进行注册，对于每个等级，都会单独生成一个 `$pwd/log/$level` 文件储存日志。
- 此实现的问题在于，对于每个单独的日志文件，其中均会输出所有 <= 该等级的所有日志，即 `error.log` 中包含所有等级为 `ERROR`, `CRITICAL` 的日志，`warning.log` 中包含所有等级为 `WARNING`, `ERROR`, `CRITICAL` 的日志。

上述行为不符合一般用户的使用预期，故调整为：
- 当 `logpile_level` 配置非元组时，插件会自动选取配置的日志等级进行注册，所有 <= 该注册等级的日志均会被储存在 `$pwd/log/$level` 文件中